### PR TITLE
Allow access to autoscaling to apigroup

### DIFF
--- a/roles.yaml
+++ b/roles.yaml
@@ -4,7 +4,7 @@ metadata:
   name: $NAMESPACE-user-full-access
   namespace: $NAMESPACE
 rules:
-- apiGroups: ["", "extensions", "apps"]
+- apiGroups: ["", "extensions", "apps", "autoscaling"]
   resources: ["*"]
   verbs: ["*"]
 - apiGroups: ["batch"]


### PR DESCRIPTION
@nicks  `kubectl get all` requests for resource `horizontalpodautoscalers` in `autoscaling` group.



